### PR TITLE
Store prompts and credentials in files

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,21 +8,22 @@ This application converts a PDF document into a summarized PowerPoint presentati
 - Generates a PowerPoint presentation with up to five bullet points per slide and relevant images.
 - Simple web interface built with Streamlit.
 - Runs inside Docker and can be orchestrated with Docker Compose.
+- All prompts are stored in text files inside `prompts/` and loaded at
+  application start.
+- API credentials are persisted in `config.json` after the first run.
 
 ## Usage
 
-1. Set your Azure OpenAI credentials in `docker-compose.yml` or as environment variables:
-   - `OPENAI_API_KEY`
-   - `OPENAI_API_BASE`
-   - `OPENAI_API_VERSION`
-   - `OPENAI_DEPLOYMENT`
-
-2. Build and start the service:
+1. Build and start the service:
 
 ```bash
 docker compose up --build
 ```
 
-3. Open `http://localhost:8501` in your browser, upload a PDF and generate the presentation.
+2. Open `http://localhost:8501` in your browser. On the first launch you will be
+   asked for your Azure OpenAI credentials. They will be stored in `config.json`
+   and reused on subsequent runs. You can change them later via "Edit
+   Configuration" in the sidebar.
 
-The resulting PowerPoint file can be downloaded directly from the interface.
+3. Upload a PDF and generate the presentation. The resulting PowerPoint file can
+   be downloaded directly from the interface.

--- a/app.py
+++ b/app.py
@@ -1,3 +1,4 @@
+import json
 import os
 import streamlit as st
 
@@ -5,12 +6,62 @@ import streamlit as st
 from openai import AzureOpenAI
 from pdf_to_ppt import pdf_to_ppt
 
+
+CONFIG_FILE = "config.json"
+
+
+def load_config():
+    if os.path.exists(CONFIG_FILE):
+        with open(CONFIG_FILE, "r", encoding="utf-8") as f:
+            return json.load(f)
+    return {
+        "api_base": os.getenv("OPENAI_API_BASE", ""),
+        "api_key": os.getenv("OPENAI_API_KEY", ""),
+        "api_version": os.getenv("OPENAI_API_VERSION", "2023-07-01-preview"),
+        "deployment": os.getenv("OPENAI_DEPLOYMENT", ""),
+    }
+
+
+def save_config(data: dict):
+    with open(CONFIG_FILE, "w", encoding="utf-8") as f:
+        json.dump(data, f)
+
+
 st.title("PDF to PowerPoint Summary")
 
-api_base = st.text_input("Azure OpenAI API Base", value=os.getenv("OPENAI_API_BASE", ""))
-api_key = st.text_input("Azure OpenAI API Key", type="password", value=os.getenv("OPENAI_API_KEY", ""))
-api_version = st.text_input("Azure OpenAI API Version", value=os.getenv("OPENAI_API_VERSION", "2023-07-01-preview"))
-deployment = st.text_input("Deployment Name", value=os.getenv("OPENAI_DEPLOYMENT", ""))
+config = load_config()
+
+# Show configuration editor if no config is present or user requests it
+edit_config = False
+if not os.path.exists(CONFIG_FILE):
+    st.info("Please enter your Azure OpenAI configuration.")
+    edit_config = True
+else:
+    edit_config = st.sidebar.checkbox("Edit Configuration")
+
+if edit_config:
+    api_base = st.text_input("Azure OpenAI API Base", value=config.get("api_base", ""))
+    api_key = st.text_input("Azure OpenAI API Key", type="password", value=config.get("api_key", ""))
+    api_version = st.text_input(
+        "Azure OpenAI API Version",
+        value=config.get("api_version", "2023-07-01-preview"),
+    )
+    deployment = st.text_input("Deployment Name", value=config.get("deployment", ""))
+    if st.button("Save Configuration"):
+        config = {
+            "api_base": api_base,
+            "api_key": api_key,
+            "api_version": api_version,
+            "deployment": deployment,
+        }
+        save_config(config)
+        st.success("Configuration saved. You can now generate a presentation.")
+        st.experimental_rerun()
+else:
+    api_base = config.get("api_base", "")
+    api_key = config.get("api_key", "")
+    api_version = config.get("api_version", "2023-07-01-preview")
+    deployment = config.get("deployment", "")
 
 uploaded_file = st.file_uploader("Upload PDF", type=["pdf"])
 

--- a/pdf_to_ppt.py
+++ b/pdf_to_ppt.py
@@ -2,6 +2,25 @@ import io
 import os
 from typing import List
 
+# Path to the system prompt used for summarization
+PROMPT_FILE = os.path.join(os.path.dirname(__file__), "prompts", "summarize.txt")
+
+
+def _load_prompt() -> str:
+    """Load the system prompt from the prompts directory."""
+    try:
+        with open(PROMPT_FILE, "r", encoding="utf-8") as f:
+            return f.read().strip()
+    except FileNotFoundError:
+        # Fallback prompt if the file does not exist
+        return (
+            "Summarize the following text into at most 5 concise bullet points."
+            "Respond with a bullet list in the same language as the text."
+        )
+
+
+SYSTEM_PROMPT = _load_prompt()
+
 import fitz  # PyMuPDF
 from pptx import Presentation
 from pptx.util import Inches
@@ -55,10 +74,7 @@ from openai import AzureOpenAI
 def summarize_text(text: str, client: AzureOpenAI, deployment: str, max_tokens: int = 256) -> List[str]:
 
     """Use Azure OpenAI to summarize text into bullet points."""
-    system_prompt = (
-        "Summarize the following text into at most 5 concise bullet points."
-        "Respond with a bullet list in the same language as the text."
-    )
+    system_prompt = SYSTEM_PROMPT
     messages = [
         {"role": "system", "content": system_prompt},
         {"role": "user", "content": text},

--- a/prompts/summarize.txt
+++ b/prompts/summarize.txt
@@ -1,0 +1,2 @@
+Summarize the following text into at most 5 concise bullet points.
+Respond with a bullet list in the same language as the text.


### PR DESCRIPTION
## Summary
- load system prompt from prompts/summarize.txt
- keep Azure OpenAI credentials in config.json and allow editing through the UI
- document new behaviour in README

## Testing
- `python -m py_compile app.py pdf_to_ppt.py`

------
https://chatgpt.com/codex/tasks/task_b_6856cdc9cd64832397add27e3a739057