### PR TITLE
Store prompts and credentials in files

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,5 @@ docker compose up --build
 2. Open `http://localhost:8501` in your browser. On the first launch you will be asked for your Azure OpenAI API key. Endpoint, deployment and version are pre-filled from the Docker compose file and stored in `config.json` for reuse. You can adjust them later via "Edit Configuration" in the sidebar.
 
 3. Upload a PDF and generate the presentation. The resulting PowerPoint file can be downloaded directly from the interface.
+
+To add more summarization languages, edit the `LANGUAGE_OPTIONS` dictionary in `app.py`.

--- a/README.md
+++ b/README.md
@@ -8,11 +8,9 @@ This application converts a PDF document into a summarized PowerPoint presentati
 - Generates a PowerPoint presentation with up to five bullet points per slide and relevant images.
 - Simple web interface built with Streamlit.
 - Runs inside Docker and can be orchestrated with Docker Compose.
-- All prompts are stored in text files inside `prompts/` and loaded at
-  application start.
+- All prompts are stored in text files inside `prompts/` and loaded at application start.
 - API credentials are persisted in `config.json` after the first run.
-- The summarization language can be chosen (detected from the PDF, German,
-  English, Spanish or Chinese by default).
+- The summarization language can be chosen (detected from the PDF, German, English, Spanish or Chinese by default).
 - Both the system prompt and API configuration can be edited from the sidebar.
 
 ## Usage
@@ -23,10 +21,6 @@ This application converts a PDF document into a summarized PowerPoint presentati
 docker compose up --build
 ```
 
-2. Open `http://localhost:8501` in your browser. On the first launch you will be
-   asked for your Azure OpenAI API key. Endpoint, deployment and version are
-   pre-filled from the Docker compose file and can be adjusted later via "Edit
-   Configuration" in the sidebar.
+2. Open `http://localhost:8501` in your browser. On the first launch you will be asked for your Azure OpenAI API key. Endpoint, deployment and version are pre-filled from the Docker compose file and stored in `config.json` for reuse. You can adjust them later via "Edit Configuration" in the sidebar.
 
-3. Upload a PDF and generate the presentation. The resulting PowerPoint file can
-   be downloaded directly from the interface.
+3. Upload a PDF and generate the presentation. The resulting PowerPoint file can be downloaded directly from the interface.

--- a/README.md
+++ b/README.md
@@ -8,21 +8,25 @@ This application converts a PDF document into a summarized PowerPoint presentati
 - Generates a PowerPoint presentation with up to five bullet points per slide and relevant images.
 - Simple web interface built with Streamlit.
 - Runs inside Docker and can be orchestrated with Docker Compose.
+- All prompts are stored in text files inside `prompts/` and loaded at
+  application start.
+- API credentials are persisted in `config.json` after the first run.
+- The summarization language can be chosen (detected from the PDF, German,
+  English, Spanish or Chinese by default).
+- Both the system prompt and API configuration can be edited from the sidebar.
 
 ## Usage
 
-1. Set your Azure OpenAI credentials in `docker-compose.yml` or as environment variables:
-   - `OPENAI_API_KEY`
-   - `OPENAI_API_BASE`
-   - `OPENAI_API_VERSION`
-   - `OPENAI_DEPLOYMENT`
-
-2. Build and start the service:
+1. Build and start the service:
 
 ```bash
 docker compose up --build
 ```
 
-3. Open `http://localhost:8501` in your browser, upload a PDF and generate the presentation.
+2. Open `http://localhost:8501` in your browser. On the first launch you will be
+   asked for your Azure OpenAI API key. Endpoint, deployment and version are
+   pre-filled from the Docker compose file and can be adjusted later via "Edit
+   Configuration" in the sidebar.
 
-The resulting PowerPoint file can be downloaded directly from the interface.
+3. Upload a PDF and generate the presentation. The resulting PowerPoint file can
+   be downloaded directly from the interface.

--- a/app.py
+++ b/app.py
@@ -1,18 +1,113 @@
+import json
 import os
 import streamlit as st
 
 
 from openai import AzureOpenAI
-from pdf_to_ppt import pdf_to_ppt
+from pdf_to_ppt import (
+    pdf_to_ppt,
+    detect_pdf_language,
+    load_prompt,
+    save_prompt,
+)
+
+
+CONFIG_FILE = "config.json"
+
+LANGUAGE_OPTIONS = {
+    "German": "de",
+    "English": "en",
+    "Spanish": "es",
+    "Chinese": "zh",
+}
+
+LANGUAGE_NAMES = {v: k for k, v in LANGUAGE_OPTIONS.items()}
+
+
+def load_config():
+    if os.path.exists(CONFIG_FILE):
+        with open(CONFIG_FILE, "r", encoding="utf-8") as f:
+            return json.load(f)
+    return {
+        "api_base": os.getenv("OPENAI_API_BASE", ""),
+        "api_key": os.getenv("OPENAI_API_KEY", ""),
+        "api_version": os.getenv("OPENAI_API_VERSION", "2023-07-01-preview"),
+        "deployment": os.getenv("OPENAI_DEPLOYMENT", ""),
+    }
+
+
+def save_config(data: dict):
+    with open(CONFIG_FILE, "w", encoding="utf-8") as f:
+        json.dump(data, f)
+
 
 st.title("PDF to PowerPoint Summary")
 
-api_base = st.text_input("Azure OpenAI API Base", value=os.getenv("OPENAI_API_BASE", ""))
-api_key = st.text_input("Azure OpenAI API Key", type="password", value=os.getenv("OPENAI_API_KEY", ""))
-api_version = st.text_input("Azure OpenAI API Version", value=os.getenv("OPENAI_API_VERSION", "2023-07-01-preview"))
-deployment = st.text_input("Deployment Name", value=os.getenv("OPENAI_DEPLOYMENT", ""))
+config = load_config()
+
+edit_prompt = st.sidebar.checkbox("Edit Prompt")
+
+# Show configuration editor if no config is present or user requests it
+edit_config = False
+if not os.path.exists(CONFIG_FILE):
+    st.info("Please enter your Azure OpenAI configuration.")
+    edit_config = True
+else:
+    edit_config = st.sidebar.checkbox("Edit Configuration")
+
+if edit_config:
+    api_base = st.text_input("Azure OpenAI API Base", value=config.get("api_base", ""))
+    api_key = st.text_input("Azure OpenAI API Key", type="password", value=config.get("api_key", ""))
+    api_version = st.text_input(
+        "Azure OpenAI API Version",
+        value=config.get("api_version", "2023-07-01-preview"),
+    )
+    deployment = st.text_input("Deployment Name", value=config.get("deployment", ""))
+    if st.button("Save Configuration"):
+        config = {
+            "api_base": api_base,
+            "api_key": api_key,
+            "api_version": api_version,
+            "deployment": deployment,
+        }
+        save_config(config)
+        st.success("Configuration saved. You can now generate a presentation.")
+        st.experimental_rerun()
+else:
+    api_base = config.get("api_base", "")
+    api_key = config.get("api_key", "")
+    api_version = config.get("api_version", "2023-07-01-preview")
+    deployment = config.get("deployment", "")
+
+if edit_prompt:
+    current_prompt = load_prompt()
+    new_prompt = st.text_area("System Prompt", value=current_prompt, height=200)
+    if st.button("Save Prompt"):
+        save_prompt(new_prompt)
+        st.success("Prompt saved.")
 
 uploaded_file = st.file_uploader("Upload PDF", type=["pdf"])
+
+language_code = ""
+if uploaded_file:
+    if (
+        "pdf_lang" not in st.session_state
+        or st.session_state.get("file_name") != uploaded_file.name
+    ):
+        with open("input.pdf", "wb") as f:
+            f.write(uploaded_file.read())
+        detected = detect_pdf_language("input.pdf")
+        st.session_state["pdf_lang"] = detected
+        st.session_state["file_name"] = uploaded_file.name
+    detected_code = st.session_state.get("pdf_lang", "en")
+    detected_name = LANGUAGE_NAMES.get(detected_code, detected_code)
+    st.write(f"Detected language: {detected_name}")
+    options = [f"PDF language ({detected_name})"] + list(LANGUAGE_OPTIONS.keys())
+    choice = st.selectbox("Summarization language", options)
+    if choice.startswith("PDF"):
+        language_code = detected_code
+    else:
+        language_code = LANGUAGE_OPTIONS[choice]
 
 if st.button("Generate PowerPoint") and uploaded_file:
     with open("input.pdf", "wb") as f:
@@ -27,7 +122,7 @@ if st.button("Generate PowerPoint") and uploaded_file:
 
     output_path = "output.pptx"
     with st.spinner("Processing PDF..."):
-        pdf_to_ppt("input.pdf", output_path, client, deployment)
+        pdf_to_ppt("input.pdf", output_path, client, deployment, language=language_code)
 
 
     with open(output_path, "rb") as f:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     ports:
       - "8501:8501"
     environment:
-      OPENAI_API_KEY: "YOUR_API_KEY"
-      OPENAI_API_BASE: "YOUR_ENDPOINT"
-      OPENAI_API_VERSION: "2023-07-01-preview"
-      OPENAI_DEPLOYMENT: "DEPLOYMENT_NAME"
+      OPENAI_API_KEY: ""
+      OPENAI_API_BASE: "https://blue-dev-openai.openai.azure.com/"
+      OPENAI_API_VERSION: "2024-12-01-preview"
+      OPENAI_DEPLOYMENT: "paper2ppt-gpt-4o"

--- a/pdf_to_ppt.py
+++ b/pdf_to_ppt.py
@@ -2,9 +2,36 @@ import io
 import os
 from typing import List
 
+from langdetect import detect
+
+# Path to the system prompt used for summarization
+PROMPT_FILE = os.path.join(os.path.dirname(__file__), "prompts", "summarize.txt")
+
+
+def load_prompt() -> str:
+    """Load the system prompt from the prompts directory."""
+    try:
+        with open(PROMPT_FILE, "r", encoding="utf-8") as f:
+            return f.read().strip()
+    except FileNotFoundError:
+        # Fallback prompt if the file does not exist
+        return (
+            "Summarize the following text into at most 5 concise bullet points."
+            " Respond in {language}."
+        )
+
+
+def save_prompt(content: str) -> None:
+    """Persist the system prompt to disk."""
+    with open(PROMPT_FILE, "w", encoding="utf-8") as f:
+        f.write(content)
+
+
+SYSTEM_PROMPT = load_prompt()
+
 import fitz  # PyMuPDF
 from pptx import Presentation
-from pptx.util import Inches
+from pptx.util import Inches, Pt
 
 
 def extract_pages(pdf_path: str):
@@ -24,6 +51,19 @@ def extract_pages(pdf_path: str):
     doc.close()
 
 
+def detect_pdf_language(pdf_path: str) -> str:
+    """Detect predominant language of the PDF text."""
+    text_snippets = []
+    for _, text, _ in extract_pages(pdf_path):
+        text_snippets.append(text)
+        if len(" ".join(text_snippets)) > 1000:
+            break
+    try:
+        return detect(" ".join(text_snippets))
+    except Exception:
+        return "en"
+
+
 def create_slide(prs: Presentation, title: str, bullets: List[str], images: List[bytes]):
     """Add a slide with a title, bullet points and images."""
     slide_layout = prs.slide_layouts[1]
@@ -31,34 +71,52 @@ def create_slide(prs: Presentation, title: str, bullets: List[str], images: List
     slide.shapes.title.text = title
 
     body = slide.shapes.placeholders[1].text_frame
-    body.text = ''
+    body.text = ""
     for point in bullets:
         p = body.add_paragraph()
         p.text = point
         p.level = 0
+        p.font.size = Pt(32)
 
     for img_bytes, ext in images:
         image_stream = io.BytesIO(img_bytes)
         slide.shapes.add_picture(image_stream, Inches(1), Inches(3), height=Inches(3))
 
 
+def _add_bullet_slides(prs: Presentation, title: str, bullets: List[str], images: List[bytes]):
+    """Create one or more slides ensuring bullet lists fit."""
+    MAX_BULLETS = 5
+    for idx in range(0, len(bullets), MAX_BULLETS):
+        group = bullets[idx : idx + MAX_BULLETS]
+        slide_title = title if idx == 0 else f"{title} (cont.)"
+        create_slide(prs, slide_title, group, images if idx == 0 else [])
+
+
 def save_presentation(sections, output_path: str):
     prs = Presentation()
     for title, bullets, images in sections:
-        create_slide(prs, title, bullets, images)
+        _add_bullet_slides(prs, title, bullets, images)
     prs.save(output_path)
 
 
 from openai import AzureOpenAI
 
 
-def summarize_text(text: str, client: AzureOpenAI, deployment: str, max_tokens: int = 256) -> List[str]:
+def summarize_text(
+    text: str,
+    client: AzureOpenAI,
+    deployment: str,
+    *,
+    language: str = "",
+    max_tokens: int = 256,
+) -> List[str]:
 
     """Use Azure OpenAI to summarize text into bullet points."""
-    system_prompt = (
-        "Summarize the following text into at most 5 concise bullet points."
-        "Respond with a bullet list in the same language as the text."
-    )
+    system_prompt = SYSTEM_PROMPT
+    if "{language}" in system_prompt:
+        system_prompt = system_prompt.format(language=language or "the original language")
+    elif language:
+        system_prompt = f"{system_prompt}\nRespond in {language}."
     messages = [
         {"role": "system", "content": system_prompt},
         {"role": "user", "content": text},
@@ -75,11 +133,18 @@ def summarize_text(text: str, client: AzureOpenAI, deployment: str, max_tokens: 
     return bullets
 
 
-def pdf_to_ppt(pdf_path: str, output_path: str, client: AzureOpenAI, deployment: str):
+def pdf_to_ppt(
+    pdf_path: str,
+    output_path: str,
+    client: AzureOpenAI,
+    deployment: str,
+    *,
+    language: str = "",
+) -> None:
     sections = []
     for page_num, text, images in extract_pages(pdf_path):
         title = f"Page {page_num}"
-        bullets = summarize_text(text, client, deployment)
+        bullets = summarize_text(text, client, deployment, language=language)
 
         sections.append((title, bullets, images))
     save_presentation(sections, output_path)

--- a/prompts/summarize.txt
+++ b/prompts/summarize.txt
@@ -1,0 +1,2 @@
+Summarize the following text into at most 5 concise bullet points.
+Respond in {language}.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ openai
 streamlit
 python-pptx
 PyMuPDF
+langdetect


### PR DESCRIPTION
## Summary
- load system prompt from prompts/summarize.txt
- keep Azure OpenAI credentials in config.json and allow editing through the UI
- document new behaviour in README
- language detection and selection for summaries
- allow editing the summarization prompt
- add slide splitting and font size limit
- add default Azure OpenAI settings in docker-compose

## Testing
- `python -m py_compile app.py pdf_to_ppt.py`


------
https://chatgpt.com/codex/tasks/task_b_6856cdc9cd64832397add27e3a739057