### PR TITLE
Resolve prompt path reference error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# Docker image for running the Paper2PPT app
 FROM python:3.10-slim
 
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -5,24 +5,30 @@ This application converts a PDF document into a summarized PowerPoint presentati
 ## Features
 - Extracts text and images from each page of the uploaded PDF.
 - Summarizes the text using Azure OpenAI and creates bullet points.
+- Uses a language model to decide if extracted images are relevant to the page text before adding them to slides.
 - Generates a PowerPoint presentation with up to five bullet points per slide and relevant images.
+- Chooses at most one relevant image per slide based on an LLM score.
+- User interface language can be switched (English, German, Spanish or Chinese by default).
 - Simple web interface built with Streamlit.
 - Runs inside Docker and can be orchestrated with Docker Compose.
+- All prompts are stored in text files inside `prompts/` and loaded at application start. The default summarization prompt lives in `prompts/summarize.txt` and can be edited from the sidebar.
+- The relevance check prompt for images resides in `prompts/image_eval.txt` and is also editable.
+- The title creation prompt is stored in `prompts/title.txt`.
+- API credentials are persisted in `config.json` after the first run.
+- The summarization language can be chosen (detected from the PDF or the languages listed in `settings.json`).
+- Both the system prompt and API configuration can be edited from the sidebar.
+- Formatting options like font size and maximum words per bullet are defined in `settings.json`.
 
 ## Usage
 
-1. Set your Azure OpenAI credentials in `docker-compose.yml` or as environment variables:
-   - `OPENAI_API_KEY`
-   - `OPENAI_API_BASE`
-   - `OPENAI_API_VERSION`
-   - `OPENAI_DEPLOYMENT`
-
-2. Build and start the service:
+1. Build and start the service:
 
 ```bash
 docker compose up --build
 ```
 
-3. Open `http://localhost:8501` in your browser, upload a PDF and generate the presentation.
+2. Open `http://localhost:8501` in your browser. On the first launch you will be asked for your Azure OpenAI API key. Endpoint, deployment and version are pre-filled from the Docker compose file and stored in `config.json` for reuse. You can adjust them later via "Edit Configuration" in the sidebar.
 
-The resulting PowerPoint file can be downloaded directly from the interface.
+3. Upload a PDF and generate the presentation. The resulting PowerPoint file can be downloaded directly from the interface.
+
+To add more summarization or UI languages, edit the `languages` section in `settings.json`.

--- a/app.py
+++ b/app.py
@@ -1,24 +1,183 @@
+"""Streamlit UI for converting PDF files to PowerPoint
+with Azure OpenAI summarization.
+
+The app loads prompts and settings from disk and allows
+users to edit them via the sidebar."""
+
+import json
 import os
 import streamlit as st
 
 
 from openai import AzureOpenAI
-from pdf_to_ppt import pdf_to_ppt
+from pdf_to_ppt import (
+    pdf_to_ppt,
+    detect_pdf_language,
+    load_prompt,
+    save_prompt,
+    IMAGE_PROMPT_PATH,
+    TITLE_PROMPT_PATH,
+    load_settings,
+)
 
-st.title("PDF to PowerPoint Summary")
 
-api_base = st.text_input("Azure OpenAI API Base", value=os.getenv("OPENAI_API_BASE", ""))
-api_key = st.text_input("Azure OpenAI API Key", type="password", value=os.getenv("OPENAI_API_KEY", ""))
-api_version = st.text_input("Azure OpenAI API Version", value=os.getenv("OPENAI_API_VERSION", "2023-07-01-preview"))
-deployment = st.text_input("Deployment Name", value=os.getenv("OPENAI_DEPLOYMENT", ""))
+CONFIG_FILE = "config.json"
 
-uploaded_file = st.file_uploader("Upload PDF", type=["pdf"])
+SETTINGS = load_settings()
+LANGUAGE_OPTIONS = SETTINGS.get("languages", {})
+LANGUAGE_NAMES = {v: k for k, v in LANGUAGE_OPTIONS.items()}
 
-if st.button("Generate PowerPoint") and uploaded_file:
+# Text labels for the UI in different languages
+TRANSLATIONS = {
+    "en": {
+        "title": "PDF to PowerPoint Summary",
+        "upload": "Upload PDF",
+        "generate": "Generate PowerPoint",
+        "detected": "Detected language",
+        "summarization": "Summarization language",
+    },
+    "de": {
+        "title": "PDF zu PowerPoint Zusammenfassung",
+        "upload": "PDF hochladen",
+        "generate": "PowerPoint erstellen",
+        "detected": "Erkannte Sprache",
+        "summarization": "Sprache der Zusammenfassung",
+    },
+    "es": {
+        "title": "Resumen PDF a PowerPoint",
+        "upload": "Subir PDF",
+        "generate": "Generar PowerPoint",
+        "detected": "Idioma detectado",
+        "summarization": "Idioma del resumen",
+    },
+    "zh": {
+        "title": "PDF\u8f6cPowerPoint\u6458\u8981",
+        "upload": "\u4e0a\u4f20PDF",
+        "generate": "\u751f\u6210PPT",
+        "detected": "\u68c0\u6d4b\u8bed\u8a00",
+        "summarization": "\u6458\u8981\u8bed\u8a00",
+    },
+}
+
+
+def load_config():
+    """Return saved API settings or defaults from env vars."""
+    if os.path.exists(CONFIG_FILE):
+        with open(CONFIG_FILE, "r", encoding="utf-8") as f:
+            return json.load(f)
+    return {
+        "api_base": os.getenv("OPENAI_API_BASE", ""),
+        "api_key": os.getenv("OPENAI_API_KEY", ""),
+        "api_version": os.getenv("OPENAI_API_VERSION", "2023-07-01-preview"),
+        "deployment": os.getenv("OPENAI_DEPLOYMENT", ""),
+    }
+
+
+def save_config(data: dict):
+    """Persist API settings to disk."""
+    with open(CONFIG_FILE, "w", encoding="utf-8") as f:
+        json.dump(data, f)
+
+
+ui_choice = st.sidebar.selectbox("UI Language", list(LANGUAGE_OPTIONS.keys()))
+ui_code = LANGUAGE_OPTIONS[ui_choice]
+TR = TRANSLATIONS.get(ui_code, TRANSLATIONS["en"])
+
+st.title(TR["title"])
+
+config = load_config()
+
+# Sidebar switch to allow editing of the LLM prompts
+edit_prompt = st.sidebar.checkbox("Edit Prompt")
+
+# Show configuration editor on first run or when the user selects "Edit Configuration"
+edit_config = False
+if not os.path.exists(CONFIG_FILE):
+    st.info("Please enter your Azure OpenAI configuration.")
+    edit_config = True
+else:
+    edit_config = st.sidebar.checkbox("Edit Configuration")
+
+# When editing is enabled show input fields for all settings
+if edit_config:
+    api_base = st.text_input("Azure OpenAI API Base", value=config.get("api_base", ""))
+    api_key = st.text_input("Azure OpenAI API Key", type="password", value=config.get("api_key", ""))
+    api_version = st.text_input(
+        "Azure OpenAI API Version",
+        value=config.get("api_version", "2023-07-01-preview"),
+    )
+    deployment = st.text_input("Deployment Name", value=config.get("deployment", ""))
+    if st.button("Save Configuration"):
+        config = {
+            "api_base": api_base,
+            "api_key": api_key,
+            "api_version": api_version,
+            "deployment": deployment,
+        }
+        save_config(config)
+        st.success("Configuration saved. You can now generate a presentation.")
+        st.experimental_rerun()
+else:
+    # Use the previously saved configuration values
+    api_base = config.get("api_base", "")
+    api_key = config.get("api_key", "")
+    api_version = config.get("api_version", "2023-07-01-preview")
+    deployment = config.get("deployment", "")
+
+if edit_prompt:
+    # Load current prompt texts so they can be edited in the sidebar
+    current_summary = load_prompt()
+    current_image = load_prompt(IMAGE_PROMPT_PATH)
+    current_title = load_prompt(TITLE_PROMPT_PATH)
+    new_summary = st.text_area(
+        "Summarization Prompt", value=current_summary, height=200
+    )
+    new_image = st.text_area(
+        "Image Relevance Prompt", value=current_image, height=200
+    )
+    new_title = st.text_area(
+        "Title Prompt", value=current_title, height=150
+    )
+    if st.button("Save Prompts"):
+        save_prompt(new_summary)
+        save_prompt(new_image, IMAGE_PROMPT_PATH)
+        save_prompt(new_title, TITLE_PROMPT_PATH)
+        st.success("Prompts saved.")
+
+uploaded_file = st.file_uploader(TR["upload"], type=["pdf"])
+
+language_code = ""
+# When a PDF is uploaded we detect its main language
+if uploaded_file:
+    if (
+        # Detect language once per uploaded file
+        "pdf_lang" not in st.session_state
+        or st.session_state.get("file_name") != uploaded_file.name
+    ):
+        # Save the file so PyMuPDF can read it
+        with open("input.pdf", "wb") as f:
+            f.write(uploaded_file.read())
+        # Use a helper to detect the main language of the PDF
+        detected = detect_pdf_language("input.pdf")
+        st.session_state["pdf_lang"] = detected
+        st.session_state["file_name"] = uploaded_file.name
+    detected_code = st.session_state.get("pdf_lang", "en")
+    detected_name = LANGUAGE_NAMES.get(detected_code, detected_code)
+    st.write(f"{TR['detected']}: {detected_name}")
+    # Allow the user to override the detected language for summarization
+    options = [f"PDF language ({detected_name})"] + list(LANGUAGE_OPTIONS.keys())
+    choice = st.selectbox(TR["summarization"], options)
+    if choice.startswith("PDF"):
+        language_code = detected_code
+    else:
+        language_code = LANGUAGE_OPTIONS[choice]
+
+if st.button(TR["generate"]) and uploaded_file:
     with open("input.pdf", "wb") as f:
         f.write(uploaded_file.read())
 
 
+    # Initialize the OpenAI client with our settings
     client = AzureOpenAI(
         api_key=api_key,
         api_version=api_version,
@@ -26,11 +185,14 @@ if st.button("Generate PowerPoint") and uploaded_file:
     )
 
     output_path = "output.pptx"
+    # Convert the PDF to a PowerPoint using the helper module
+    # Perform the heavy conversion work
     with st.spinner("Processing PDF..."):
-        pdf_to_ppt("input.pdf", output_path, client, deployment)
+        pdf_to_ppt("input.pdf", output_path, client, deployment, language=language_code)
 
 
     with open(output_path, "rb") as f:
+        # Offer the resulting file for download
         st.download_button(
             label="Download PowerPoint",
             data=f,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,13 @@
+# Docker Compose setup for the Streamlit app
 version: "3"
 services:
   app:
     build: .
     ports:
       - "8501:8501"
+    # Default Azure OpenAI configuration
     environment:
-      OPENAI_API_KEY: "YOUR_API_KEY"
-      OPENAI_API_BASE: "YOUR_ENDPOINT"
-      OPENAI_API_VERSION: "2023-07-01-preview"
-      OPENAI_DEPLOYMENT: "DEPLOYMENT_NAME"
+      OPENAI_API_KEY: ""
+      OPENAI_API_BASE: "https://blue-dev-openai.openai.azure.com/"
+      OPENAI_API_VERSION: "2024-12-01-preview"
+      OPENAI_DEPLOYMENT: "paper2ppt-gpt-4o"

--- a/pdf_to_ppt.py
+++ b/pdf_to_ppt.py
@@ -1,14 +1,83 @@
+"""Utility helpers used by the Streamlit front end.
+
+This module handles extracting content from PDF files,
+interacting with Azure OpenAI to create summaries and titles,
+and building the final PowerPoint presentation."""
 import io
 import os
+from pathlib import Path
 from typing import List
+import base64
+import json
+
+from langdetect import detect
+
+# Location of the text files containing the prompts
+# Path to the system prompt used for summarization
+PROMPT_PATH = Path(__file__).resolve().parent / "prompts" / "summarize.txt"
+# Path to the image relevance evaluation prompt
+IMAGE_PROMPT_PATH = Path(__file__).resolve().parent / "prompts" / "image_eval.txt"
+# Path to the slide title prompt
+TITLE_PROMPT_PATH = Path(__file__).resolve().parent / "prompts" / "title.txt"
+
+# Settings file controlling language options and formatting
+SETTINGS_FILE = Path(__file__).resolve().parent / "settings.json"
+
+# Default values used when settings.json is missing
+DEFAULT_SETTINGS = {
+    "languages": {
+        "English": "en",
+        "German": "de",
+        "Spanish": "es",
+        "Chinese": "zh",
+    },
+    "font_size": 24,
+    "max_words_per_bullet": 10,
+    "max_words_title": 4,
+}
+
+
+def load_settings() -> dict:
+    """Read settings from settings.json or use defaults."""
+    if SETTINGS_FILE.exists():
+        with open(SETTINGS_FILE, "r", encoding="utf-8") as f:
+            return json.load(f)
+    return DEFAULT_SETTINGS
+
+
+def load_prompt(path: Path = PROMPT_PATH) -> str:
+    """Load the system prompt from the prompts directory."""
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return f.read().strip()
+    except FileNotFoundError:
+        # Fallback prompt if the file does not exist
+        return (
+            "Summarize the following text into at most 5 concise bullet points."
+            " Respond in {language}."
+        )
+
+
+def save_prompt(content: str, path: Path = PROMPT_PATH) -> None:
+    """Persist the system prompt to disk."""
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(content)
+
+
+SYSTEM_PROMPT = load_prompt()
+IMAGE_PROMPT = load_prompt(IMAGE_PROMPT_PATH)
+TITLE_PROMPT = load_prompt(TITLE_PROMPT_PATH)
+
+SETTINGS = load_settings()
 
 import fitz  # PyMuPDF
 from pptx import Presentation
-from pptx.util import Inches
+from pptx.util import Inches, Pt
 
 
 def extract_pages(pdf_path: str):
     """Extract text and images from each page of a PDF."""
+    # Open the PDF with PyMuPDF
     doc = fitz.open(pdf_path)
     for page_num in range(len(doc)):
         page = doc.load_page(page_num)
@@ -21,44 +90,93 @@ def extract_pages(pdf_path: str):
             ext = base_image["ext"]
             images.append((image_bytes, ext))
         yield page_num + 1, text, images
+    # Close the document to free resources
     doc.close()
+
+
+def detect_pdf_language(pdf_path: str) -> str:
+    """Detect predominant language of the PDF text."""
+    text_snippets = []
+    for _, text, _ in extract_pages(pdf_path):
+        text_snippets.append(text)
+        if len(" ".join(text_snippets)) > 1000:
+            break
+    try:
+        return detect(" ".join(text_snippets))
+    except Exception:
+        return "en"
 
 
 def create_slide(prs: Presentation, title: str, bullets: List[str], images: List[bytes]):
     """Add a slide with a title, bullet points and images."""
+    # Use the "Title and Content" layout
     slide_layout = prs.slide_layouts[1]
     slide = prs.slides.add_slide(slide_layout)
     slide.shapes.title.text = title
 
-    body = slide.shapes.placeholders[1].text_frame
-    body.text = ''
+    body_placeholder = slide.shapes.placeholders[1]
+    body_placeholder.left = Inches(0.5)
+    body_placeholder.top = Inches(1.5)
+    body_placeholder.width = Inches(5)
+    body_placeholder.height = Inches(4.5)
+    body = body_placeholder.text_frame
+    # Remove any existing text from the placeholder
+    body.clear()
     for point in bullets:
         p = body.add_paragraph()
         p.text = point
         p.level = 0
+        p.font.size = Pt(SETTINGS.get("font_size", 24))
 
-    for img_bytes, ext in images:
+    if images:
+        img_bytes, ext = images[0]
         image_stream = io.BytesIO(img_bytes)
-        slide.shapes.add_picture(image_stream, Inches(1), Inches(3), height=Inches(3))
+        slide.shapes.add_picture(image_stream, Inches(5.6), Inches(1.5), height=Inches(4))
+
+
+def _add_bullet_slides(prs: Presentation, title: str, bullets: List[str], images: List[bytes]):
+    """Create one or more slides ensuring bullet lists fit."""
+    # Only five bullets fit on a single slide
+    MAX_BULLETS = 5
+    for idx in range(0, len(bullets), MAX_BULLETS):
+        group = bullets[idx : idx + MAX_BULLETS]
+        slide_title = title if idx == 0 else f"{title} (cont.)"
+        create_slide(prs, slide_title, group, images if idx == 0 else [])
 
 
 def save_presentation(sections, output_path: str):
+    """Write all slides to a PowerPoint file."""
+
     prs = Presentation()
+    # Add each section of content as one or more slides
     for title, bullets, images in sections:
-        create_slide(prs, title, bullets, images)
+        _add_bullet_slides(prs, title, bullets, images)
+    # Finally write the presentation to disk
     prs.save(output_path)
 
 
 from openai import AzureOpenAI
 
 
-def summarize_text(text: str, client: AzureOpenAI, deployment: str, max_tokens: int = 256) -> List[str]:
+def summarize_text(
+    text: str,
+    client: AzureOpenAI,
+    deployment: str,
+    *,
+    language: str = "",
+    max_tokens: int = 256,
+) -> List[str]:
 
     """Use Azure OpenAI to summarize text into bullet points."""
-    system_prompt = (
-        "Summarize the following text into at most 5 concise bullet points."
-        "Respond with a bullet list in the same language as the text."
-    )
+    system_prompt = SYSTEM_PROMPT
+    # Insert the configured word limit into the prompt if needed
+    max_words = SETTINGS.get("max_words_per_bullet", 10)
+    if "{max_words}" in system_prompt:
+        system_prompt = system_prompt.replace("{max_words}", str(max_words))
+    if "{language}" in system_prompt:
+        system_prompt = system_prompt.replace("{language}", language or "the original language")
+    elif language:
+        system_prompt = f"{system_prompt}\nRespond in {language}."
     messages = [
         {"role": "system", "content": system_prompt},
         {"role": "user", "content": text},
@@ -72,15 +190,114 @@ def summarize_text(text: str, client: AzureOpenAI, deployment: str, max_tokens: 
     content = response.choices[0].message.content
 
     bullets = [line.lstrip("- ").strip() for line in content.splitlines() if line]
-    return bullets
+    trimmed = []
+    # Truncate each bullet to the configured word limit
+    for b in bullets:
+        # Split the bullet into words
+        words = b.split()
+        # Truncate bullet to configured word limit
+        if len(words) > max_words:
+            words = words[:max_words]
+        # Rebuild the bullet string
+        trimmed.append(" ".join(words))
+    return trimmed
 
 
-def pdf_to_ppt(pdf_path: str, output_path: str, client: AzureOpenAI, deployment: str):
+def generate_title(
+    text: str,
+    client: AzureOpenAI,
+    deployment: str,
+    *,
+    language: str = "",
+    max_tokens: int = 16,
+) -> str:
+    """Generate a short slide title."""
+
+    max_words = SETTINGS.get("max_words_title", 4)
+    prompt = TITLE_PROMPT
+    # Replace placeholders in the title prompt
+    if "{max_words}" in prompt:
+        prompt = prompt.replace("{max_words}", str(max_words))
+    if "{language}" in prompt:
+        prompt = prompt.replace("{language}", language or "the original language")
+    elif language:
+        prompt = f"{prompt}\nRespond in {language}."
+    # Prepare the conversation for the chat completion call
+    messages = [
+        {"role": "system", "content": prompt},
+        {"role": "user", "content": text},
+    ]
+    response = client.chat.completions.create(
+        model=deployment,
+        messages=messages,
+        max_tokens=max_tokens,
+    )
+    return response.choices[0].message.content.strip()
+
+
+def evaluate_image_relevance(
+    page_text: str,
+    image: bytes,
+    ext: str,
+    client: AzureOpenAI,
+    deployment: str,
+    *,
+    max_tokens: int = 8,
+) -> float:
+    """Return an image relevance score between 0 and 10."""
+    # The API expects a base64 encoded data URL for the image
+    b64 = base64.b64encode(image).decode("utf-8")
+    mime = f"data:image/{ext};base64,{b64}"
+    # Combine the page text and the image into a single chat request
+    messages = [
+        {"role": "system", "content": IMAGE_PROMPT},
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": page_text},
+                {"type": "image_url", "image_url": {"url": mime}},
+            ],
+        },
+    ]
+    try:
+        response = client.chat.completions.create(
+            model=deployment,
+            messages=messages,
+            max_tokens=max_tokens,
+        )
+        answer = response.choices[0].message.content.strip()
+        return float(answer)
+    except Exception:
+        return 0.0
+
+
+def pdf_to_ppt(
+    pdf_path: str,
+    output_path: str,
+    client: AzureOpenAI,
+    deployment: str,
+    *,
+    language: str = "",
+) -> None:
+    # Collect (title, bullets, [image]) tuples for each page
     sections = []
+    # Minimum relevance score an image must achieve to be used
+    min_score = SETTINGS.get("min_image_score", 5)
+    # Process each page of the PDF individually
     for page_num, text, images in extract_pages(pdf_path):
-        title = f"Page {page_num}"
-        bullets = summarize_text(text, client, deployment)
+        title = generate_title(text, client, deployment, language=language)
+        bullets = summarize_text(text, client, deployment, language=language)
+        best_img = None
+        best_score = -1.0
+        # Evaluate all images and keep the highest scoring one
+        for img_bytes, ext in images:
+            score = evaluate_image_relevance(text, img_bytes, ext, client, deployment)
+            if score > best_score:
+                best_score = score
+                best_img = (img_bytes, ext)
+        relevant_images = [best_img] if best_img and best_score >= min_score else []
 
-        sections.append((title, bullets, images))
+        sections.append((title, bullets, relevant_images))
+    # Write all collected slides to the output file
     save_presentation(sections, output_path)
 

--- a/prompts/image_eval.txt
+++ b/prompts/image_eval.txt
@@ -1,0 +1,1 @@
+Rate how much the image helps understand the accompanying text on a scale from 0 (irrelevant) to 10 (very relevant). Respond with a single number.

--- a/prompts/summarize.txt
+++ b/prompts/summarize.txt
@@ -1,0 +1,3 @@
+Summarize the following text into at most 5 concise bullet points.
+Each bullet should be no more than {max_words} words.
+Respond in {language}.

--- a/prompts/title.txt
+++ b/prompts/title.txt
@@ -1,0 +1,1 @@
+Provide an informative slide title of at most {max_words} words. Respond in {language}.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ openai
 streamlit
 python-pptx
 PyMuPDF
+langdetect

--- a/settings.json
+++ b/settings.json
@@ -1,0 +1,12 @@
+{
+  "languages": {
+    "English": "en",
+    "German": "de",
+    "Spanish": "es",
+    "Chinese": "zh"
+  },
+  "font_size": 24,
+  "max_words_per_bullet": 10,
+  "max_words_title": 4,
+  "min_image_score": 5
+}


### PR DESCRIPTION
## Summary
- clarify prompt file location in README
- use Path object for PROMPT_PATH constant
- load and save prompts using PROMPT_PATH
- filter page images using a new LLM relevance prompt
- allow editing both summarization, title and image prompts
- fix bullet slide initialization
- add configurable settings for languages and font size
- choose the most relevant image per page
- translate minimal UI labels and store defaults in settings.json
- add explanatory comments for maintainability

## Testing
- `python -m py_compile app.py pdf_to_ppt.py`


------
https://chatgpt.com/codex/tasks/task_b_6856cdc9cd64832397add27e3a739057