### PR TITLE
Add Playwright login example

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,17 @@ docker compose up --build
 
 To add more summarization or UI languages, edit the `languages` section in `settings.json`.
 
+
+## Playwright Login Example
+
+The `playwright_login` folder contains a small example that logs into
+`https://serviceteam-witt.kilanka.de` using Playwright. Put your credentials in
+`playwright_login/credentials.json` and run the container:
+
+```bash
+cd playwright_login
+docker compose run --build login
+```
+
+This will launch a headless browser, perform the login and print the page title
+after the login attempt.

--- a/playwright_login/Dockerfile
+++ b/playwright_login/Dockerfile
@@ -1,0 +1,12 @@
+# Use official Playwright image with Python
+FROM mcr.microsoft.com/playwright/python:v1.42.0-jammy
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY login.py ./
+COPY credentials.json ./
+
+CMD ["python", "login.py"]

--- a/playwright_login/credentials.json
+++ b/playwright_login/credentials.json
@@ -1,0 +1,4 @@
+{
+  "username": "your_username",
+  "password": "your_password"
+}

--- a/playwright_login/docker-compose.yml
+++ b/playwright_login/docker-compose.yml
@@ -1,0 +1,5 @@
+version: '3.8'
+services:
+  login:
+    build: .
+    command: python login.py

--- a/playwright_login/login.py
+++ b/playwright_login/login.py
@@ -1,0 +1,30 @@
+import asyncio
+import json
+from pathlib import Path
+from playwright.async_api import async_playwright
+
+CREDENTIALS_FILE = Path(__file__).parent / "credentials.json"
+
+async def main():
+    if not CREDENTIALS_FILE.exists():
+        raise FileNotFoundError(f"Credentials file {CREDENTIALS_FILE} not found")
+    creds = json.loads(CREDENTIALS_FILE.read_text())
+    username = creds.get("username")
+    password = creds.get("password")
+    if not username or not password:
+        raise ValueError("username and password must be provided in credentials.json")
+
+    async with async_playwright() as pw:
+        browser = await pw.chromium.launch(headless=True)
+        context = await browser.new_context()
+        page = await context.new_page()
+        await page.goto("https://serviceteam-witt.kilanka.de")
+        await page.fill('input[name="username"]', username)
+        await page.fill('input[name="password"]', password)
+        await page.click('button[type="submit"]')
+        await page.wait_for_load_state('networkidle')
+        print(await page.title())
+        await browser.close()
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/playwright_login/requirements.txt
+++ b/playwright_login/requirements.txt
@@ -1,0 +1,1 @@
+playwright


### PR DESCRIPTION
## Summary
- add a simple Playwright script to log in to `serviceteam-witt.kilanka.de`
- provide Dockerfile and compose file for running the login example
- document how to run the example in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685982b3b8308323abe4a4599d167e64